### PR TITLE
Improve built-in browser window controls

### DIFF
--- a/sources/Alife.Function/Alife.Function.Browser/BrowserEngine.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/BrowserEngine.cs
@@ -23,9 +23,10 @@ public class BrowserEngine : IDisposable
     /// <summary>
     /// 跳转到指定页面
     /// </summary>
-    public Task<NavigateResult> NavigateAsync(string url)
+    public async Task<NavigateResult> NavigateAsync(string url)
     {
-        return worker.AddFormTask(async webView => {
+        await worker.ShowBrowserWindowAsync();
+        return await worker.AddFormTask(async webView => {
             var tcs = new TaskCompletionSource<NavigateResult>();
             webView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
             webView.CoreWebView2.Navigate(url);

--- a/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
@@ -5,10 +5,6 @@ using Microsoft.Web.WebView2.WinForms;
 
 namespace Alife.Function.Browser;
 
-/// <summary>
-/// 在独立的 STA 线程中管理 WebView2，以支持后台执行浏览器任务。
-/// 浏览器窗口默认可见，用户可实时观察 AI 的浏览行为并手动介入。
-/// </summary>
 public class WebViewWorker : IDisposable
 {
     public bool IsNavigating => isNavigating;
@@ -38,18 +34,31 @@ public class WebViewWorker : IDisposable
         return tcs.Task;
     }
 
+    public Task ShowBrowserWindowAsync()
+    {
+        return AddFormTask(webView => {
+            ShowBrowserWindow();
+            return Task.FromResult(webView);
+        });
+    }
+
     AlifeForm? form;
     WebView2? webView;
+    Button? backButton;
+    Button? forwardButton;
+    Button? refreshButton;
+    Button? goButton;
+    TextBox? addressTextBox;
     readonly BlockingCollection<Func<Task>> formTasks = new();
     bool isNavigating;
     bool isLoaded;
+    bool isDisposing;
 
     public WebViewWorker()
     {
         var thread = new Thread(() => {
             try
             {
-                //创建窗口
                 form = new AlifeForm {
                     Text = "Alife Browser",
                     Width = 1024,
@@ -58,11 +67,14 @@ public class WebViewWorker : IDisposable
                     ShowInTaskbar = true,
                     FormBorderStyle = FormBorderStyle.Sizable,
                 };
+
                 webView = new WebView2 { Dock = DockStyle.Fill };
+                Control toolbar = CreateToolbar();
 
                 form.Controls.Add(webView);
-                //注入窗口初始化事件
+                form.Controls.Add(toolbar);
                 form.Load += OnFormOnLoad;
+                form.FormClosing += OnFormClosing;
 
                 Application.Run(form);
             }
@@ -78,16 +90,195 @@ public class WebViewWorker : IDisposable
 
     public void Dispose()
     {
+        isDisposing = true;
         formTasks.CompleteAdding();
         if (form is { IsDisposed: false })
             form.Invoke((Action)(() => form.Close()));
+    }
+
+    Control CreateToolbar()
+    {
+        TableLayoutPanel toolbar = new() {
+            Dock = DockStyle.Top,
+            Height = 36,
+            ColumnCount = 5,
+            RowCount = 1,
+            Padding = new Padding(4),
+        };
+        toolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 68));
+        toolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 76));
+        toolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 76));
+        toolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+        toolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 56));
+
+        backButton = CreateToolbarButton("Back");
+        forwardButton = CreateToolbarButton("Forward");
+        refreshButton = CreateToolbarButton("Refresh");
+        goButton = CreateToolbarButton("Go");
+        addressTextBox = new TextBox {
+            Dock = DockStyle.Fill,
+            BorderStyle = BorderStyle.FixedSingle,
+            PlaceholderText = "about:blank",
+        };
+
+        backButton.Click += (_, _) => {
+            if (webView?.CoreWebView2?.CanGoBack == true)
+                webView.CoreWebView2.GoBack();
+        };
+        forwardButton.Click += (_, _) => {
+            if (webView?.CoreWebView2?.CanGoForward == true)
+                webView.CoreWebView2.GoForward();
+        };
+        refreshButton.Click += (_, _) => webView?.CoreWebView2?.Reload();
+        goButton.Click += (_, _) => NavigateFromAddressBar();
+        addressTextBox.KeyDown += (_, e) => {
+            if (e.KeyCode != Keys.Enter)
+                return;
+
+            e.SuppressKeyPress = true;
+            NavigateFromAddressBar();
+        };
+
+        toolbar.Controls.Add(backButton, 0, 0);
+        toolbar.Controls.Add(forwardButton, 1, 0);
+        toolbar.Controls.Add(refreshButton, 2, 0);
+        toolbar.Controls.Add(addressTextBox, 3, 0);
+        toolbar.Controls.Add(goButton, 4, 0);
+
+        UpdateBrowserChrome();
+        return toolbar;
+    }
+
+    static Button CreateToolbarButton(string text) =>
+        new() {
+            Text = text,
+            Dock = DockStyle.Fill,
+            Margin = new Padding(2),
+        };
+
+    void NavigateFromAddressBar()
+    {
+        if (webView?.CoreWebView2 == null || addressTextBox == null)
+            return;
+
+        string input = addressTextBox.Text;
+        if (!TryNormalizeUserUrl(input, out string url, out string error))
+        {
+            Console.WriteLine(error);
+            addressTextBox.Text = error;
+            return;
+        }
+
+        webView.CoreWebView2.Navigate(url);
+    }
+
+    static bool TryNormalizeUserUrl(string input, out string url, out string error)
+    {
+        url = "";
+        error = "";
+        string trimmed = input.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            error = "Navigation blocked: empty URL.";
+            return false;
+        }
+
+        if (trimmed.Equals("about:blank", StringComparison.OrdinalIgnoreCase))
+        {
+            url = "about:blank";
+            return true;
+        }
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri))
+            trimmed = $"https://{trimmed}";
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out uri))
+        {
+            error = $"Navigation blocked: invalid URL '{input}'.";
+            return false;
+        }
+
+        if (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+            uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            url = uri.AbsoluteUri;
+            return true;
+        }
+
+        error = $"Navigation blocked: unsupported scheme '{uri.Scheme}'.";
+        return false;
+    }
+
+    void OnFormClosing(object? sender, FormClosingEventArgs e)
+    {
+        if (isDisposing)
+            return;
+
+        e.Cancel = true;
+        HideAndUnloadCurrentPage();
+    }
+
+    void HideAndUnloadCurrentPage()
+    {
+        if (webView?.CoreWebView2 != null)
+        {
+            try
+            {
+                webView.CoreWebView2.Stop();
+                webView.CoreWebView2.Navigate("about:blank");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        isNavigating = false;
+        UpdateBrowserChrome("about:blank");
+        form?.Hide();
+    }
+
+    void ShowBrowserWindow()
+    {
+        if (form == null || form.IsDisposed)
+            return;
+
+        if (form.WindowState == FormWindowState.Minimized)
+            form.WindowState = FormWindowState.Normal;
+        form.Show();
+        form.Activate();
+    }
+
+    void UpdateBrowserChrome(string? overrideUrl = null)
+    {
+        bool ready = webView?.CoreWebView2 != null;
+        if (backButton != null)
+            backButton.Enabled = ready && webView!.CoreWebView2.CanGoBack;
+        if (forwardButton != null)
+            forwardButton.Enabled = ready && webView!.CoreWebView2.CanGoForward;
+        if (refreshButton != null)
+            refreshButton.Enabled = ready;
+        if (goButton != null)
+            goButton.Enabled = ready;
+
+        string currentUrl = overrideUrl ??
+                            webView?.Source?.ToString() ??
+                            webView?.CoreWebView2?.Source ??
+                            "about:blank";
+        if (addressTextBox != null)
+            addressTextBox.Text = currentUrl;
+
+        if (form != null)
+        {
+            string title = webView?.CoreWebView2?.DocumentTitle ?? "";
+            form.Text = string.IsNullOrWhiteSpace(title) ? "Alife Browser" : $"Alife Browser - {title}";
+        }
     }
 
     async void OnFormOnLoad(object? s, EventArgs e)
     {
         try
         {
-            //初始化基本环境
             string userDataFolder = Path.Combine(AlifePath.StorageFolderPath, "WebView2Data");
             if (!Directory.Exists(userDataFolder))
                 Directory.CreateDirectory(userDataFolder);
@@ -95,20 +286,25 @@ public class WebViewWorker : IDisposable
 
             await form!.InvokeAsync(async _ => {
                 await webView!.EnsureCoreWebView2Async(env);
-                //伪装普通浏览器
                 webView.CoreWebView2.Settings.UserAgent =
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edge/122.0.0.0";
-                //禁用新窗口跳转
                 webView.CoreWebView2.NewWindowRequested += (_, ev) => {
                     ev.Handled = true;
                     webView.CoreWebView2.Navigate(ev.Uri);
                 };
-                //统计加载状态
-                webView.CoreWebView2.NavigationStarting += (_, ev) => isNavigating = true;
-                webView.CoreWebView2.NavigationCompleted += (_, ev) => isNavigating = false;
+                webView.CoreWebView2.NavigationStarting += (_, ev) => {
+                    isNavigating = true;
+                    UpdateBrowserChrome(ev.Uri);
+                };
+                webView.CoreWebView2.NavigationCompleted += (_, _) => {
+                    isNavigating = false;
+                    UpdateBrowserChrome();
+                };
+                webView.CoreWebView2.SourceChanged += (_, _) => UpdateBrowserChrome();
+                webView.CoreWebView2.DocumentTitleChanged += (_, _) => UpdateBrowserChrome();
+                UpdateBrowserChrome();
             });
 
-            //持续处理分配的formTask任务
             isLoaded = true;
             await Task.Run(() => {
                 foreach (Func<Task> formTask in formTasks.GetConsumingEnumerable())
@@ -135,17 +331,4 @@ public class WebViewWorker : IDisposable
     }
 }
 
-public class AlifeForm : Form
-{
-    const int CP_NOCLOSE_BUTTON = 0x200;
-
-    protected override CreateParams CreateParams
-    {
-        get
-        {
-            CreateParams myCp = base.CreateParams;
-            myCp.ClassStyle = myCp.ClassStyle | CP_NOCLOSE_BUTTON;
-            return myCp;
-        }
-    }
-}
+public class AlifeForm : Form;


### PR DESCRIPTION
This PR improves the built-in WebView2 browser window usability without changing SurfingService or AI browser capabilities.

Changes:
- Adds a minimal toolbar: Back / Forward / Refresh / editable address bar / Go.
- Restores the window X as the only close/hide entry.
- Window close hides the form and unloads the current page to about:blank without disposing WebView2.
- Supports manual URL entry, Enter-to-navigate, and automatic https:// prefix for bare domains.
- Allows only http, https, and about:blank from the manual address bar.
- Keeps existing SurfingService Navigate / Observe / RunJs / Download behavior unchanged.
- Does not add tabs, multi-window management, download manager, bookmarks, history, or a new permission system.

Validation:
- Scoped browser project build passed:
  dotnet build .\sources\Alife.Function\Alife.Function.Browser\Alife.Function.Browser.csproj --artifacts-path .\work\artifacts
- Full solution build was not used for this PR because the current upstream master references a missing Tests/Alife.Test.Speech/Alife.Test.Speech.csproj.
- Manual UI check was performed locally before preparing this PR: toolbar appears, address bar navigation works, Back/Forward/Refresh work, and window close hides/unloads the page.