### PR TITLE
添加聊天显示控制与内部输入隐藏

### DIFF
--- a/Tests/Alife.Test.Interpreter/ChatDisplayFilterTests.cs
+++ b/Tests/Alife.Test.Interpreter/ChatDisplayFilterTests.cs
@@ -1,0 +1,97 @@
+using Alife.Framework;
+
+[TestFixture]
+public class ChatDisplayFilterTests
+{
+    [Test]
+    public void ReasoningDisplayPolicy_RespectsClientToggle()
+    {
+        Assert.That(
+            ChatMessageDisplayPolicy.ShouldDisplayAssistantMessage("", "thinking", false, false),
+            Is.False);
+        Assert.That(
+            ChatMessageDisplayPolicy.ShouldDisplayAssistantMessage("", "thinking", false, true),
+            Is.True);
+    }
+
+    [Test]
+    public void InputVisibility_DistinguishesVisibleAndInternalInputs()
+    {
+        ChatInputSentEventArgs visible = new("user input", ChatInputVisibility.Visible);
+        ChatInputSentEventArgs internalInput = new("tool result", ChatInputVisibility.Internal);
+
+        Assert.That(visible.DisplayInputMessageInChat, Is.True);
+        Assert.That(internalInput.DisplayInputMessageInChat, Is.False);
+    }
+
+    [Test]
+    public void InternalInput_CanStillLeadToVisibleAssistantReply()
+    {
+        ChatInputSentEventArgs internalInput = new("tool result", ChatInputVisibility.Internal);
+
+        Assert.That(internalInput.DisplayInputMessageInChat, Is.False);
+        Assert.That(
+            ChatMessageDisplayPolicy.ShouldDisplayAssistantMessage("assistant reply", null, false, false),
+            Is.True);
+    }
+
+    [Test]
+    public void DisplayFilter_MapsAllowedExpressionTags()
+    {
+        Assert.That(
+            AssistantDisplayTextFilter.Filter(@"<expression option=""委屈"" />"),
+            Is.EqualTo("<委屈>"));
+        Assert.That(
+            AssistantDisplayTextFilter.Filter(@"<expression option=""思考状"" />"),
+            Is.EqualTo("<思考状>"));
+    }
+
+    [Test]
+    public void DisplayFilter_MapsSpeakToNaturalDialogue()
+    {
+        Assert.That(
+            AssistantDisplayTextFilter.Filter("<speak>测试</speak>"),
+            Is.EqualTo("「测试」"));
+        Assert.That(
+            AssistantDisplayTextFilter.Filter("<speak>   </speak>"),
+            Is.EqualTo(""));
+    }
+
+    [Test]
+    public void DisplayFilter_RemovesOtherXmlFunctionTags()
+    {
+        Assert.That(
+            AssistantDisplayTextFilter.Filter("<bubble>你好</bubble>"),
+            Is.EqualTo(""));
+        Assert.That(
+            AssistantDisplayTextFilter.Filter(@"<expression option=""开心"" />"),
+            Is.EqualTo(""));
+        Assert.That(
+            AssistantDisplayTextFilter.Filter("<unknown>secret</unknown>"),
+            Is.EqualTo(""));
+        Assert.That(
+            AssistantDisplayTextFilter.Filter("hello <partial"),
+            Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void DisplayFilter_SuppressesBlankAssistantBubbleAfterTagOnlyOutput()
+    {
+        string display = AssistantDisplayTextFilter.Filter("<bubble>你好</bubble>");
+
+        Assert.That(display, Is.EqualTo(""));
+        Assert.That(
+            ChatMessageDisplayPolicy.ShouldDisplayAssistantMessage(display, null, false, false),
+            Is.False);
+    }
+
+    [Test]
+    public void DisplayFilter_DoesNotMutateRawAssistantText()
+    {
+        string raw = "<speak>测试</speak>";
+        string display = AssistantDisplayTextFilter.Filter(raw);
+
+        Assert.That(raw, Is.EqualTo("<speak>测试</speak>"));
+        Assert.That(display, Is.EqualTo("「测试」"));
+    }
+}

--- a/sources/Alife.Function/Alife.Function.DeskPet/DeskPetService.cs
+++ b/sources/Alife.Function/Alife.Function.DeskPet/DeskPetService.cs
@@ -140,7 +140,7 @@ public class DeskPetService(XmlFunctionCaller functionService) : InteractivePlug
         await base.StartAsync(kernel, chatActivity);
 
         await client!.WaitReadyAsync();
-        client.OnInput += Chat;
+        client.OnInput += ChatVisible;
         client.OnInteracted += text => Chat("交互：" + text);
 
         // 启动状态轮询

--- a/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatWindowUI.razor
+++ b/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatWindowUI.razor
@@ -16,6 +16,10 @@
             <AntDesign.Text Type="@TextElementType.Secondary" Style="font-size: 12px;">最大条数:</AntDesign.Text>
             <AntDesign.InputNumber @bind-Value="ChatMessageService.MaxMessageCount" Min="10" Max="10000"
                                    Size="@InputSize.Small" Style="width: 80px; border-radius: 4px;"/>
+            <Checkbox Checked="@ChatMessageService.ShowReasoningInChat"
+                      CheckedChanged="@((bool value) => ChatMessageService.ShowReasoningInChat = value)">
+                显示思考过程
+            </Checkbox>
         </div>
         <Button Icon="@IconType.Outline.Clear"
                 Type="@ButtonType.Link"
@@ -38,12 +42,14 @@
                 {
                     @foreach (ChatMessage message in messages)
                     {
-                        <div
-                            style="display: flex; margin-bottom: 16px; width: 100%; @(message.IsUser ? "flex-direction: row-reverse" : "flex-direction: row")">
+                        @if (message.ShouldDisplay(ChatMessageService.ShowReasoningInChat))
+                        {
+                            <div
+                                style="display: flex; margin-bottom: 16px; width: 100%; @(message.IsUser ? "flex-direction: row-reverse" : "flex-direction: row")">
                             <div class="chat-bubble @(message.IsUser ? "chat-bubble-user" : "chat-bubble-ai")">
                                 <Flex Direction="@FlexDirection.Vertical" Gap="@("small")">
                                     <div class="chat-message-content">
-                                        @if (!string.IsNullOrEmpty(message.Reasoning))
+                                        @if (ChatMessageService.ShowReasoningInChat && !string.IsNullOrEmpty(message.Reasoning))
                                         {
                                             <div class="chat-reasoning">
                                                 <div class="chat-reasoning-title">
@@ -69,7 +75,8 @@
                                     }
                                 </Flex>
                             </div>
-                        </div>
+                            </div>
+                        }
                     }
                 }
             }

--- a/sources/Alife/Alife.Client/Components/Pages/SystemManagementPage.razor
+++ b/sources/Alife/Alife.Client/Components/Pages/SystemManagementPage.razor
@@ -1,9 +1,11 @@
 @page "/system"
 @using Alife.Components.Elements.Character
 @using Alife.Components.Elements.Plugin
+@using Alife.Components.Services
 @inject NavigationManager Navigation
 @inject CharacterSystem CharacterSystem
 @inject ChatActivitySystem ChatActivitySystem
+@inject ChatMessageService ChatMessageService
 @inject ConfirmService ConfirmService
 @inject INotificationService NotificationService
 @inject ConfigurationSystem ConfigurationSystem
@@ -83,6 +85,38 @@
                                                 Stopped="@(() => ChatActivitySystem.Deactivate(chatActivity.Character))"></ChatActivityUI>
                             }
                         </div>
+                    </div>
+                </ChildContent>
+            </TabPane>
+
+            <TabPane Key="4">
+                <TabTemplate>
+                    <Flex Direction="@FlexDirection.Vertical" Align="@FlexAlign.Center" Gap="@("4")">
+                        <Icon Type="@IconType.Outline.Comment"/>
+                        <span style="font-size: 12px">聊天显示</span>
+                    </Flex>
+                </TabTemplate>
+                <ChildContent>
+                    <div style="padding: 24px; height: 100%; overflow-y: auto; background: #fafafa;">
+                        <Title Level="4">聊天显示</Title>
+                        <Card Style="max-width: 720px; border-radius: 8px;">
+                            <Flex Direction="@FlexDirection.Vertical" Gap="@("16")">
+                                <div style="display: flex; justify-content: space-between; gap: 24px; align-items: flex-start;">
+                                    <div>
+                                        <Text Strong>显示思考过程</Text>
+                                        <Paragraph Type="@TextElementType.Secondary"
+                                                   Style="margin: 4px 0 0 0; max-width: 520px;">
+                                            关闭后，聊天面板不会显示模型返回的 reasoning/thinking 内容。
+                                        </Paragraph>
+                                    </div>
+                                    <Switch @bind-Value="@ChatMessageService.ShowReasoningInChat"/>
+                                </div>
+                                <Alert Message="内部/插件触发消息"
+                                       Description="系统事件、插件观察、桌宠交互等内部输入目前默认不会显示为聊天气泡，但仍可用于驱动 AI 回复。当前版本未提供单独的持久显示开关。"
+                                       Type="@AlertType.Info"
+                                       ShowIcon="true"/>
+                            </Flex>
+                        </Card>
                     </div>
                 </ChildContent>
             </TabPane>

--- a/sources/Alife/Alife.Client/Components/Services/ChatMessageService.cs
+++ b/sources/Alife/Alife.Client/Components/Services/ChatMessageService.cs
@@ -6,14 +6,34 @@ public class ChatSettings
 {
     public string UserTag { get; set; } = "[管理员]";
     public int MaxMessageCount { get; set; } = 200;
+    public bool ShowReasoningInChat { get; set; }
 }
 
 public class ChatMessage
 {
     public string? Content { get; set; }
+    public string? RawContent { get; set; }
     public string? Reasoning { get; set; }
     public bool IsUser { get; set; }
     public bool IsInputting { get; set; }
+
+    public void AppendAssistantContent(string content)
+    {
+        RawContent += content;
+        Content = AssistantDisplayTextFilter.Filter(RawContent);
+    }
+
+    public bool ShouldDisplay(bool showReasoning)
+    {
+        if (IsInputting || IsUser)
+            return true;
+
+        return ChatMessageDisplayPolicy.ShouldDisplayAssistantMessage(
+            Content,
+            Reasoning,
+            IsInputting,
+            showReasoning);
+    }
 }
 
 /// <summary>
@@ -41,6 +61,17 @@ public class ChatMessageService
         {
             settings.MaxMessageCount = value;
             SaveSettings();
+        }
+    }
+    public bool ShowReasoningInChat
+    {
+        get => settings.ShowReasoningInChat;
+        set
+        {
+            settings.ShowReasoningInChat = value;
+            SaveSettings();
+            foreach (string name in messagesMap.Keys)
+                OnMessageChanged?.Invoke(name);
         }
     }
 
@@ -108,22 +139,24 @@ public class ChatMessageService
         string name = activity.Character.Name;
         List<ChatMessage> messages = GetMessages(name);
         chatbotMap.Add(name, activity.ChatBot);
-        activity.ChatBot.ChatSent += message => {
+        activity.ChatBot.ChatInputSent += args => {
             lock (messages)
             {
-                messages.Add(new ChatMessage { Content = message, IsUser = true });
+                if (args.DisplayInputMessageInChat)
+                    messages.Add(new ChatMessage { Content = args.Message, IsUser = true });
                 messages.Add(new ChatMessage { IsUser = false, IsInputting = true });
                 TrimMessages(name);
             }
 
             OnMessageChanged?.Invoke(name);
-            OnUserMessageSent?.Invoke(name);
+            if (args.DisplayInputMessageInChat)
+                OnUserMessageSent?.Invoke(name);
         };
         activity.ChatBot.ChatReceived += (obj) => {
             ChatMessage? aiMessage = messages.LastOrDefault(m => m is { IsUser: false, IsInputting: true });
             if (aiMessage != null)
             {
-                aiMessage.Content += obj;
+                aiMessage.AppendAssistantContent(obj);
                 OnMessageChanged?.Invoke(name);
             }
         };

--- a/sources/Alife/Alife.Framework/Models/ChatBot.cs
+++ b/sources/Alife/Alife.Framework/Models/ChatBot.cs
@@ -20,6 +20,7 @@ public class ChatBot : IAsyncDisposable
     public event Func<string, string>? PokeSend;//Poke消息过滤
     public event Func<string, string>? ChatSend;//消息过滤
     public event Action<string>? ChatSent;//消息发送前
+    public event Action<ChatInputSentEventArgs>? ChatInputSent;
     public event Action<string>? ChatReceived;//消息接收到
     public event Action<string>? ReasoningReceived;//思考消息接收到
     public event Action? ChatOver;//消息结束
@@ -40,7 +41,7 @@ public class ChatBot : IAsyncDisposable
         chatSemaphore.Release();
     }
 
-    public async IAsyncEnumerable<string> ChatStreamingAsync(string message, AuthorRole? role = null)
+    public async IAsyncEnumerable<string> ChatStreamingAsync(string message, AuthorRole? role = null, ChatInputVisibility visibility = ChatInputVisibility.Visible)
     {
         if (IsChatting)//打断上一次的聊天
         {
@@ -67,6 +68,7 @@ public class ChatBot : IAsyncDisposable
             ChaseChatHistory();
 
             ChatSent?.Invoke(message);
+            ChatInputSent?.Invoke(new ChatInputSentEventArgs(message, visibility));
             string? error = null;
             StringBuilder cleanResponseBuilder = new();// 用于存储不含思考过程的最终回复
 
@@ -159,19 +161,19 @@ public class ChatBot : IAsyncDisposable
         }
     }
 
-    public async Task<string> ChatAsync(string message, AuthorRole? role = null)
+    public async Task<string> ChatAsync(string message, AuthorRole? role = null, ChatInputVisibility visibility = ChatInputVisibility.Visible)
     {
         StringBuilder stringBuilder = new StringBuilder();
-        await foreach (string content in ChatStreamingAsync(message, role))
+        await foreach (string content in ChatStreamingAsync(message, role, visibility))
             stringBuilder.Append(content);
         return stringBuilder.ToString();
     }
 
-    public async void Chat(string content, AuthorRole? role = null)
+    public async void Chat(string content, AuthorRole? role = null, ChatInputVisibility visibility = ChatInputVisibility.Visible)
     {
         try
         {
-            await ChatAsync(content, role);
+            await ChatAsync(content, role, visibility);
         }
         catch (Exception e)
         {
@@ -291,7 +293,7 @@ public class ChatBot : IAsyncDisposable
             }
 
             //发送消息
-            Chat($"{PokeMessageTag}\n{poke}");
+            Chat($"{PokeMessageTag}\n{poke}", visibility: ChatInputVisibility.Internal);
         }
         finally
         {

--- a/sources/Alife/Alife.Framework/Models/ChatInputVisibility.cs
+++ b/sources/Alife/Alife.Framework/Models/ChatInputVisibility.cs
@@ -1,0 +1,14 @@
+namespace Alife.Framework;
+
+public enum ChatInputVisibility
+{
+    Visible,
+    Internal
+}
+
+public sealed class ChatInputSentEventArgs(string message, ChatInputVisibility visibility)
+{
+    public string Message { get; } = message;
+    public ChatInputVisibility Visibility { get; } = visibility;
+    public bool DisplayInputMessageInChat => Visibility == ChatInputVisibility.Visible;
+}

--- a/sources/Alife/Alife.Framework/Models/Plugin/InteractivePlugin.cs
+++ b/sources/Alife/Alife.Framework/Models/Plugin/InteractivePlugin.cs
@@ -88,12 +88,22 @@ public class InteractivePlugin<T> : InteractivePlugin
 
     protected void Chat(string message)
     {
-        ChatBot.Chat(ChatTextFilter(message));
+        ChatBot.Chat(ChatTextFilter(message), visibility: ChatInputVisibility.Internal);
     }
 
     protected Task ChatAsync(string message)
     {
-        return ChatBot.ChatAsync(ChatTextFilter(message));
+        return ChatBot.ChatAsync(ChatTextFilter(message), visibility: ChatInputVisibility.Internal);
+    }
+
+    protected void ChatVisible(string message)
+    {
+        ChatBot.Chat(ChatTextFilter(message), visibility: ChatInputVisibility.Visible);
+    }
+
+    protected Task ChatAsyncVisible(string message)
+    {
+        return ChatBot.ChatAsync(ChatTextFilter(message), visibility: ChatInputVisibility.Visible);
     }
 
     protected Task ImplicitChatAsync(string message)

--- a/sources/Alife/Alife.Framework/Utility/AssistantDisplayTextFilter.cs
+++ b/sources/Alife/Alife.Framework/Utility/AssistantDisplayTextFilter.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+
+namespace Alife.Framework;
+
+public static partial class AssistantDisplayTextFilter
+{
+    const string ExpressionSadPlaceholder = "%%ALIFE_EXPRESSION_SAD%%";
+    const string ExpressionThinkingPlaceholder = "%%ALIFE_EXPRESSION_THINKING%%";
+
+    public static string Filter(string? rawText)
+    {
+        if (string.IsNullOrEmpty(rawText))
+            return string.Empty;
+
+        string text = rawText;
+        text = SpeakRegex().Replace(text, match => {
+            string content = StripTags(match.Groups[1].Value).Trim();
+            return string.IsNullOrWhiteSpace(content) ? string.Empty : $"「{content}」";
+        });
+
+        text = ExpressionSadRegex().Replace(text, ExpressionSadPlaceholder);
+        text = ExpressionThinkingRegex().Replace(text, ExpressionThinkingPlaceholder);
+
+        string previous;
+        do
+        {
+            previous = text;
+            text = PairedTagRegex().Replace(text, string.Empty);
+        } while (text != previous);
+
+        text = SelfClosingTagRegex().Replace(text, string.Empty);
+        text = AnyTagOrFragmentRegex().Replace(text, string.Empty);
+
+        return text
+            .Replace(ExpressionSadPlaceholder, "<委屈>")
+            .Replace(ExpressionThinkingPlaceholder, "<思考状>")
+            .Trim();
+    }
+
+    static string StripTags(string text)
+    {
+        string previous;
+        do
+        {
+            previous = text;
+            text = PairedTagRegex().Replace(text, string.Empty);
+        } while (text != previous);
+
+        text = SelfClosingTagRegex().Replace(text, string.Empty);
+        return AnyTagOrFragmentRegex().Replace(text, string.Empty);
+    }
+
+    [GeneratedRegex("<speak\\b[^>]*>(.*?)</speak\\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex SpeakRegex();
+
+    [GeneratedRegex("<expression\\b(?=[^>]*\\boption\\s*=\\s*[\"']委屈[\"'])[^>]*/\\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex ExpressionSadRegex();
+
+    [GeneratedRegex("<expression\\b(?=[^>]*\\boption\\s*=\\s*[\"']思考状[\"'])[^>]*/\\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex ExpressionThinkingRegex();
+
+    [GeneratedRegex("<([A-Za-z][\\w:.-]*)\\b[^>]*>.*?</\\1\\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex PairedTagRegex();
+
+    [GeneratedRegex("<[A-Za-z][^<>]*/\\s*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex SelfClosingTagRegex();
+
+    [GeneratedRegex("<[^>]*(>|$)", RegexOptions.Singleline)]
+    private static partial Regex AnyTagOrFragmentRegex();
+}

--- a/sources/Alife/Alife.Framework/Utility/ChatMessageDisplayPolicy.cs
+++ b/sources/Alife/Alife.Framework/Utility/ChatMessageDisplayPolicy.cs
@@ -1,0 +1,17 @@
+namespace Alife.Framework;
+
+public static class ChatMessageDisplayPolicy
+{
+    public static bool ShouldDisplayAssistantMessage(
+        string? content,
+        string? reasoning,
+        bool isInputting,
+        bool showReasoning)
+    {
+        if (isInputting)
+            return true;
+
+        return !string.IsNullOrWhiteSpace(content) ||
+               (showReasoning && !string.IsNullOrWhiteSpace(reasoning));
+    }
+}


### PR DESCRIPTION
添加客户端侧的聊天显示控制与消息可见性处理。

主要变更：

* 添加聊天窗口设置，用于显示或隐藏reasoning/thinking内容。
* 保留reasoning的捕获与存储逻辑，不改变模型请求参数。
* 默认隐藏系统事件、插件触发等内部输入消息，避免它们显示成用户聊天气泡。
* 保留assistant回复显示，内部输入仍可用于驱动AI回复。
* 保持桌宠输入框中的用户手动输入在主聊天窗口中可见。
* 对assistant显示文本进行 UI 层过滤：
  * `<speak>测试</speak>` 显示为 `「测试」`
  * `<expression option="委屈" />` 显示为 `<委屈>`
  * `<expression option="思考状" />` 显示为 `<思考状>`
* 保留 raw assistant stream，不影响 FunctionCaller / TTS / DeskPet 等原始标签解析链路。

验证：

* Focused tests passed:
  `dotnet test .\Tests\Alife.Test.Interpreter\Alife.Test.Interpreter.csproj --filter ChatDisplayFilterTests`
* 结果：8/8 passed
* 当前完整 solution build 会被 upstream develop 现有的 SemanticKernel NU1605 package downgrade 阻塞；本 PR 未混入该 build cleanup。