### PR TITLE
添加浏览器工具栏与隐藏卸载关闭行为

### DIFF
--- a/sources/Alife.Function/Alife.Function.Browser/BrowserEngine.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/BrowserEngine.cs
@@ -39,7 +39,7 @@ public class BrowserEngine : IDisposable
                 webView.CoreWebView2.NavigationCompleted -= OnNavigationCompleted;
                 tcs.SetResult(new NavigateResult { Success = e.IsSuccess, StatusCode = (int)e.WebErrorStatus });
             }
-        });
+        }, showWindow: true);
     }
 
     /// <summary>

--- a/sources/Alife.Function/Alife.Function.Browser/UnclosableWindow.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/UnclosableWindow.cs
@@ -1,32 +1,5 @@
-using System;
-using System.Runtime.InteropServices;
 using System.Windows;
-using System.Windows.Interop;
 
 namespace Alife.Function.Browser;
 
-public class UnclosableWindow : Window
-{
-    protected override void OnSourceInitialized(EventArgs e)
-    {
-        base.OnSourceInitialized(e);
-        DisableCloseButton();
-    }
-
-    void DisableCloseButton()
-    {
-        var hwnd = new WindowInteropHelper(this).Handle;
-        if (hwnd == IntPtr.Zero) return;
-        var hMenu = GetSystemMenu(hwnd, false);
-        if (hMenu != IntPtr.Zero)
-            RemoveMenu(hMenu, SC_CLOSE, MF_BYCOMMAND);
-    }
-
-    [DllImport("user32.dll")]
-    static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
-    [DllImport("user32.dll")]
-    static extern bool RemoveMenu(IntPtr hMenu, uint uPosition, uint uFlags);
-
-    const uint SC_CLOSE = 0xF060;
-    const uint MF_BYCOMMAND = 0x00000000;
-}
+public class UnclosableWindow : Window;

--- a/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using Alife.Platform;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
@@ -19,7 +22,7 @@ public class WebViewWorker : IDisposable
     public bool IsNavigating => isNavigating;
     public bool IsLoaded => isLoaded;
 
-    public Task<T> AddFormTask<T>(Func<WebView2, Task<T>> action)
+    public Task<T> AddFormTask<T>(Func<WebView2, Task<T>> action, bool showWindow = false)
     {
         if (window == null)
             throw new ObjectDisposedException(nameof(WebViewWorker));
@@ -31,6 +34,8 @@ public class WebViewWorker : IDisposable
             {
                 if (webView == null)
                     throw new ArgumentNullException(nameof(webView));
+                if (showWindow)
+                    ShowBrowserWindow();
                 T result = await action(webView);
                 tcs.SetResult(result);
             }
@@ -45,9 +50,15 @@ public class WebViewWorker : IDisposable
 
     Window? window;
     WebView2? webView;
+    Button? backButton;
+    Button? forwardButton;
+    Button? refreshButton;
+    Button? goButton;
+    TextBox? addressBar;
     readonly BlockingCollection<Func<Task>> formTasks = new();
     bool isNavigating;
     bool isLoaded;
+    bool isDisposing;
 
     public WebViewWorker()
     {
@@ -63,9 +74,9 @@ public class WebViewWorker : IDisposable
                     ResizeMode = ResizeMode.CanResize,
                 };
                 webView = new WebView2();
-                window.Content = webView;
+                window.Content = CreateBrowserContent(webView);
                 window.Loaded += OnWindowLoaded;
-                window.Closing += (_, _) => System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
+                window.Closing += OnWindowClosing;
 
                 window.Show();
                 System.Windows.Threading.Dispatcher.Run();
@@ -82,9 +93,86 @@ public class WebViewWorker : IDisposable
 
     public void Dispose()
     {
+        isDisposing = true;
         formTasks.CompleteAdding();
         if (window != null)
-            window.Dispatcher.Invoke(() => window.Close());
+        {
+            window.Dispatcher.Invoke(() => {
+                window.Close();
+                window.Dispatcher.InvokeShutdown();
+            });
+        }
+    }
+
+    Grid CreateBrowserContent(WebView2 webViewControl)
+    {
+        backButton = CreateToolbarButton("Back");
+        forwardButton = CreateToolbarButton("Forward");
+        refreshButton = CreateToolbarButton("Refresh");
+        goButton = CreateToolbarButton("Go");
+        addressBar = new TextBox {
+            Margin = new Thickness(4, 0, 4, 0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            MinWidth = 240,
+        };
+
+        backButton.Click += (_, _) => {
+            if (webView?.CoreWebView2?.CanGoBack == true)
+                webView.CoreWebView2.GoBack();
+        };
+        forwardButton.Click += (_, _) => {
+            if (webView?.CoreWebView2?.CanGoForward == true)
+                webView.CoreWebView2.GoForward();
+        };
+        refreshButton.Click += (_, _) => webView?.CoreWebView2?.Reload();
+        goButton.Click += (_, _) => NavigateFromAddressBar();
+        addressBar.KeyDown += (_, e) => {
+            if (e.Key == Key.Enter)
+            {
+                e.Handled = true;
+                NavigateFromAddressBar();
+            }
+        };
+
+        Grid toolbar = new() { Margin = new Thickness(6) };
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        AddToolbarChild(toolbar, backButton, 0);
+        AddToolbarChild(toolbar, forwardButton, 1);
+        AddToolbarChild(toolbar, refreshButton, 2);
+        AddToolbarChild(toolbar, addressBar, 3);
+        AddToolbarChild(toolbar, goButton, 4);
+
+        Grid root = new();
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        Grid.SetRow(toolbar, 0);
+        Grid.SetRow(webViewControl, 1);
+        root.Children.Add(toolbar);
+        root.Children.Add(webViewControl);
+
+        UpdateToolbarState();
+        return root;
+    }
+
+    static Button CreateToolbarButton(string text)
+    {
+        return new Button {
+            Content = text,
+            MinWidth = 72,
+            Margin = new Thickness(0, 0, 4, 0),
+            Padding = new Thickness(8, 3, 8, 3),
+        };
+    }
+
+    static void AddToolbarChild(Grid toolbar, UIElement element, int column)
+    {
+        Grid.SetColumn(element, column);
+        toolbar.Children.Add(element);
     }
 
     async void OnWindowLoaded(object? s, RoutedEventArgs e)
@@ -104,8 +192,18 @@ public class WebViewWorker : IDisposable
                     ev.Handled = true;
                     webView.CoreWebView2.Navigate(ev.Uri);
                 };
-                webView.CoreWebView2.NavigationStarting += (_, ev) => isNavigating = true;
-                webView.CoreWebView2.NavigationCompleted += (_, ev) => isNavigating = false;
+                webView.CoreWebView2.NavigationStarting += (_, _) => {
+                    isNavigating = true;
+                    UpdateToolbarState();
+                };
+                webView.CoreWebView2.SourceChanged += (_, _) => UpdateAddressBar();
+                webView.CoreWebView2.NavigationCompleted += (_, _) => {
+                    isNavigating = false;
+                    UpdateAddressBar();
+                    UpdateToolbarState();
+                };
+                UpdateAddressBar();
+                UpdateToolbarState();
             });
 
             isLoaded = true;
@@ -128,5 +226,101 @@ public class WebViewWorker : IDisposable
         {
             Console.WriteLine(ex);
         }
+    }
+
+    void OnWindowClosing(object? sender, CancelEventArgs e)
+    {
+        if (isDisposing)
+            return;
+
+        e.Cancel = true;
+        UnloadCurrentPage();
+        window?.Hide();
+    }
+
+    void NavigateFromAddressBar()
+    {
+        if (webView?.CoreWebView2 == null || addressBar == null)
+            return;
+
+        string? url = NormalizeUserUrl(addressBar.Text);
+        if (url == null)
+        {
+            Console.WriteLine($"[Browser] Rejected user URL: {addressBar.Text}");
+            UpdateAddressBar();
+            return;
+        }
+
+        webView.CoreWebView2.Navigate(url);
+    }
+
+    static string? NormalizeUserUrl(string text)
+    {
+        string url = text.Trim();
+        if (url.Equals("about:blank", StringComparison.OrdinalIgnoreCase))
+            return "about:blank";
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            url = "https://" + url;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+                return null;
+        }
+
+        return uri.Scheme switch {
+            "http" or "https" => uri.AbsoluteUri,
+            _ => null
+        };
+    }
+
+    void ShowBrowserWindow()
+    {
+        if (window == null)
+            return;
+
+        if (!window.IsVisible)
+            window.Show();
+        if (window.WindowState == WindowState.Minimized)
+            window.WindowState = WindowState.Normal;
+        window.Activate();
+    }
+
+    void UnloadCurrentPage()
+    {
+        try
+        {
+            webView?.CoreWebView2?.Stop();
+            webView?.CoreWebView2?.Navigate("about:blank");
+            if (addressBar != null)
+                addressBar.Text = "about:blank";
+            UpdateToolbarState();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+    }
+
+    void UpdateAddressBar()
+    {
+        if (addressBar == null)
+            return;
+
+        addressBar.Text = webView?.Source?.ToString() ?? "about:blank";
+    }
+
+    void UpdateToolbarState()
+    {
+        bool ready = webView?.CoreWebView2 != null;
+        if (backButton != null)
+            backButton.IsEnabled = ready && webView!.CoreWebView2.CanGoBack;
+        if (forwardButton != null)
+            forwardButton.IsEnabled = ready && webView!.CoreWebView2.CanGoForward;
+        if (refreshButton != null)
+            refreshButton.IsEnabled = ready;
+        if (goButton != null)
+            goButton.IsEnabled = ready;
+        if (addressBar != null)
+            addressBar.IsEnabled = ready;
     }
 }


### PR DESCRIPTION
此为内置浏览器窗口添加最小工具栏，并将用户点击关闭的行为改为隐藏窗口并卸载当前页面。

主要变更：

* 添加浏览器工具栏：
  * Back
  * Forward
  * Refresh
  * 可编辑地址栏
  * Go
* 地址栏支持用户手动输入 URL。
* 用户输入 `example.com` 时自动补全为 `https://example.com`。
* 用户地址栏只允许：
  * `http://`
  * `https://`
  * `about:blank`
* 拒绝用户输入的危险 scheme，例如：
  * `file:`
  * `javascript:`
  * `data:`
* 点击关闭窗口时：
  * 停止当前页面
  * 跳转到 `about:blank`
  * 隐藏浏览器窗口
  * 不dispose WebView2
* AI再次调用浏览器时，会重新 Show / Restore / Activate 浏览器窗口并导航目标网页。
* 保持 BrowserService、Observe、RunJs、Download 语义不变。

验证：

* Browser project build passed:
  `dotnet build .\sources\Alife.Function\Alife.Function.Browser\Alife.Function.Browser.csproj --artifacts-path .\work\artifacts`
* 结果：0 warnings / 0 errors
* Manual smoke passed:

  * toolbar 可见
  * 地址栏可编辑
  * 关闭时隐藏并卸载页面
  * 再次 AI Navigate 可以重新唤醒浏览器窗口
* 当前完整 solution build 会被 upstream develop 现有的 SemanticKernel NU1605 package downgrade 阻塞；本 PR 未混入该 build cleanup。
