### PR TITLE
添加浏览器工具栏

### DIFF
--- a/sources/Alife.Function/Alife.Function.Browser/BrowserWindowContent.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/BrowserWindowContent.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace Alife.Function.Browser;
+
+public class BrowserWindowContent : Grid
+{
+    public WebView2 WebView { get; } = new();
+
+    public BrowserWindowContent()
+    {
+        CreateLayout();
+        UpdateToolbarState();
+    }
+
+    public void OnBrowserReady()
+    {
+        UpdateAddressBar();
+        UpdateToolbarState();
+    }
+
+    public void OnNavigationStateChanged()
+    {
+        UpdateAddressBar();
+        UpdateToolbarState();
+    }
+
+    readonly Button backButton = CreateToolbarButton("后退");
+    readonly Button forwardButton = CreateToolbarButton("前进");
+    readonly Button refreshButton = CreateToolbarButton("刷新");
+    readonly Button goButton = CreateToolbarButton("前往");
+    readonly TextBox addressBar = new() {
+        Text = AddressPrompt,
+        Margin = new Thickness(4, 0, 4, 0),
+        VerticalContentAlignment = VerticalAlignment.Center,
+        MinWidth = 240,
+    };
+
+    const string AddressPrompt = "输入网址";
+
+    void CreateLayout()
+    {
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+
+        Grid toolbar = CreateToolbar();
+        SetRow(toolbar, 0);
+        SetRow(WebView, 1);
+        Children.Add(toolbar);
+        Children.Add(WebView);
+
+        backButton.Click += (_, _) => {
+            if (WebView.CoreWebView2?.CanGoBack == true)
+                WebView.CoreWebView2.GoBack();
+        };
+        forwardButton.Click += (_, _) => {
+            if (WebView.CoreWebView2?.CanGoForward == true)
+                WebView.CoreWebView2.GoForward();
+        };
+        refreshButton.Click += (_, _) => WebView.CoreWebView2?.Reload();
+        goButton.Click += (_, _) => NavigateFromAddressBar();
+        addressBar.KeyDown += (_, e) => {
+            if (e.Key != Key.Enter)
+                return;
+
+            e.Handled = true;
+            NavigateFromAddressBar();
+        };
+        addressBar.GotKeyboardFocus += (_, _) => {
+            if (addressBar.Text == AddressPrompt)
+                addressBar.Text = string.Empty;
+        };
+        addressBar.LostKeyboardFocus += (_, _) => {
+            if (string.IsNullOrWhiteSpace(addressBar.Text) && WebView.Source == null)
+                addressBar.Text = AddressPrompt;
+        };
+    }
+
+    Grid CreateToolbar()
+    {
+        Grid toolbar = new() { Margin = new Thickness(6) };
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        toolbar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        AddToolbarChild(toolbar, backButton, 0);
+        AddToolbarChild(toolbar, forwardButton, 1);
+        AddToolbarChild(toolbar, refreshButton, 2);
+        AddToolbarChild(toolbar, addressBar, 3);
+        AddToolbarChild(toolbar, goButton, 4);
+        return toolbar;
+    }
+
+    static Button CreateToolbarButton(string text)
+    {
+        return new Button {
+            Content = text,
+            MinWidth = 56,
+            Margin = new Thickness(0, 0, 4, 0),
+            Padding = new Thickness(8, 3, 8, 3),
+        };
+    }
+
+    static void AddToolbarChild(Grid toolbar, UIElement element, int column)
+    {
+        SetColumn(element, column);
+        toolbar.Children.Add(element);
+    }
+
+    void NavigateFromAddressBar()
+    {
+        if (WebView.CoreWebView2 == null)
+            return;
+
+        string? url = NormalizeUserUrl(addressBar.Text);
+        if (url == null)
+        {
+            Console.WriteLine($"[Browser] 已拒绝用户输入的网址：{addressBar.Text}");
+            UpdateAddressBar();
+            return;
+        }
+
+        WebView.CoreWebView2.Navigate(url);
+    }
+
+    static string? NormalizeUserUrl(string text)
+    {
+        string url = text.Trim();
+        if (string.IsNullOrWhiteSpace(url) || url == AddressPrompt)
+            return null;
+
+        if (url.Equals("about:blank", StringComparison.OrdinalIgnoreCase))
+            return "about:blank";
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            url = "https://" + url;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+                return null;
+        }
+
+        return uri.Scheme switch {
+            "http" or "https" => uri.AbsoluteUri,
+            _ => null
+        };
+    }
+
+    void UpdateAddressBar()
+    {
+        addressBar.Text = WebView.Source?.ToString() ?? AddressPrompt;
+    }
+
+    void UpdateToolbarState()
+    {
+        Microsoft.Web.WebView2.Core.CoreWebView2? coreWebView = WebView.CoreWebView2;
+        if (coreWebView == null)
+        {
+            backButton.IsEnabled = false;
+            forwardButton.IsEnabled = false;
+            refreshButton.IsEnabled = false;
+            goButton.IsEnabled = false;
+            addressBar.IsEnabled = false;
+            return;
+        }
+
+        backButton.IsEnabled = coreWebView.CanGoBack;
+        forwardButton.IsEnabled = coreWebView.CanGoForward;
+        refreshButton.IsEnabled = true;
+        goButton.IsEnabled = true;
+        addressBar.IsEnabled = true;
+    }
+}

--- a/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
+++ b/sources/Alife.Function/Alife.Function.Browser/WebViewWorker.cs
@@ -44,6 +44,7 @@ public class WebViewWorker : IDisposable
     }
 
     Window? window;
+    BrowserWindowContent? browserContent;
     WebView2? webView;
     readonly BlockingCollection<Func<Task>> formTasks = new();
     bool isNavigating;
@@ -62,8 +63,9 @@ public class WebViewWorker : IDisposable
                     ShowInTaskbar = true,
                     ResizeMode = ResizeMode.CanResize,
                 };
-                webView = new WebView2();
-                window.Content = webView;
+                browserContent = new BrowserWindowContent();
+                webView = browserContent.WebView;
+                window.Content = browserContent;
                 window.Loaded += OnWindowLoaded;
                 window.Closing += (_, _) => System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
 
@@ -104,8 +106,16 @@ public class WebViewWorker : IDisposable
                     ev.Handled = true;
                     webView.CoreWebView2.Navigate(ev.Uri);
                 };
-                webView.CoreWebView2.NavigationStarting += (_, ev) => isNavigating = true;
-                webView.CoreWebView2.NavigationCompleted += (_, ev) => isNavigating = false;
+                webView.CoreWebView2.NavigationStarting += (_, ev) => {
+                    isNavigating = true;
+                    browserContent?.OnNavigationStateChanged();
+                };
+                webView.CoreWebView2.SourceChanged += (_, ev) => browserContent?.OnNavigationStateChanged();
+                webView.CoreWebView2.NavigationCompleted += (_, ev) => {
+                    isNavigating = false;
+                    browserContent?.OnNavigationStateChanged();
+                };
+                browserContent?.OnBrowserReady();
             });
 
             isLoaded = true;


### PR DESCRIPTION
## 主要变更

添加浏览器窗口工具栏和地址栏。

* 新增 BrowserWindowContent，负责浏览器工具栏、地址栏和 WebView2 内容布局。
* 工具栏按钮使用中文：后退 / 前进 / 刷新 / 前往。
* 地址栏支持手动输入 http://、https://、about:blank。
* 裸域名会自动补全为 https://。
* 地址栏会拒绝 file:、javascript:、data: 等非允许 scheme。

## 说明

* 保留原本 UnclosableWindow 禁用关闭行为。
* 不修改关闭、隐藏、卸载页面、自动置前或焦点逻辑。
* 不修改 Browser tool 语义。
* Toolbar UI 已拆到独立内容类中。

## 测试

* dotnet build .\Sources\Alife.Function\Alife.Function.Browser\Alife.Function.Browser.csproj --no-restore
* 手动测试了工具栏、地址栏输入、后退、前进、刷新，以及原本禁用关闭行为。
