### PR TITLE
Feature cubism2

### DIFF
--- a/sources/Alife.DeskPet/Alife.DeskPet.Client/App.xaml.cs
+++ b/sources/Alife.DeskPet/Alife.DeskPet.Client/App.xaml.cs
@@ -22,7 +22,7 @@ public partial class App
             base.OnStartup(startupEvent);
 
             string[] args = Environment.GetCommandLineArgs();
-            string defaultModel = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot/model/Mao/Mao.model3.json");
+            string defaultModel = PetModelMetadata.ResolveModelJsonPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot/model"), "Mao");
             string modelPath = args.Length > 1 ? args[1] : defaultModel;
             PetModelMetadata metadata = PetModelMetadata.Load(modelPath);
             MainWindow mainWindow = await DeskPet.MainWindow.Create();

--- a/sources/Alife.DeskPet/Alife.DeskPet.Client/PetBridge.cs
+++ b/sources/Alife.DeskPet/Alife.DeskPet.Client/PetBridge.cs
@@ -143,6 +143,11 @@ public class PetBridge : IDisposable
                 case "resize_delta":
                     OnResizeDelta?.Invoke(root.GetProperty("dx").GetDouble(), root.GetProperty("dy").GetDouble());
                     break;
+                case "log":
+                    string level = root.TryGetProperty("level", out JsonElement levelProp) ? levelProp.GetString() ?? "log" : "log";
+                    string text = root.TryGetProperty("text", out JsonElement textProp) ? textProp.GetString() ?? "" : "";
+                    _ = File.AppendAllTextAsync("pet.log", $"[WebView {level}] {text}{Environment.NewLine}");
+                    break;
             }
         }
         catch (Exception ex)

--- a/sources/Alife.DeskPet/Alife.DeskPet.Client/wwwroot/pet.js
+++ b/sources/Alife.DeskPet/Alife.DeskPet.Client/wwwroot/pet.js
@@ -6,6 +6,56 @@ const ui = {
     sendBtn: document.getElementById("send-btn")
 };
 
+function formatLogArg(arg) {
+    if (arg instanceof Error) return `${arg.name}: ${arg.message}\n${arg.stack || ""}`;
+    if (typeof arg === "object") {
+        try {
+            return JSON.stringify(arg);
+        } catch {
+            return String(arg);
+        }
+    }
+    return String(arg);
+}
+
+function postLog(level, ...args) {
+    try {
+        window.chrome.webview.postMessage({
+            type: "log",
+            level,
+            text: args.map(formatLogArg).join(" ")
+        });
+    } catch {
+        // ignored
+    }
+}
+
+{
+    const rawWarn = console.warn.bind(console);
+    const rawError = console.error.bind(console);
+    console.warn = (...args) => {
+        postLog("warn", ...args);
+        rawWarn(...args);
+    };
+    console.error = (...args) => {
+        postLog("error", ...args);
+        rawError(...args);
+    };
+}
+
+window.addEventListener("error", (e) => {
+    const target = e.target;
+    if (target && target !== window) {
+        postLog("resource-error", target.tagName || "unknown", target.src || target.href || "");
+        return;
+    }
+    postLog("error", e.message, `${e.filename}:${e.lineno}:${e.colno}`, e.error || "");
+}, true);
+
+window.addEventListener("unhandledrejection", (e) => {
+    postLog("unhandledrejection", e.reason);
+});
+
 const app = new PIXI.Application({
     view: document.getElementById("canvas"),
     autoStart: true,
@@ -27,10 +77,18 @@ window.chrome.webview.addEventListener("message", (e) => {
             break;
         //修改表情
         case "expression":
+            if (!model) {
+                console.warn("[Pet] Ignore expression because model is not loaded:", msg.id);
+                break;
+            }
             model.expression(msg.id);
             break;
         //修改动作
         case "motion":
+            if (!model) {
+                console.warn("[Pet] Ignore motion because model is not loaded:", msg.group, msg.index);
+                break;
+            }
             model.motion(msg.group, msg.index, PIXI.live2d.MotionPriority.FORCE);
             break;
         //修改气泡文字
@@ -43,6 +101,7 @@ window.chrome.webview.addEventListener("message", (e) => {
             break;
         //修改注视目标
         case "look":
+            if (!model) break;
             model.focus(msg.x, msg.y, msg.instant);
             break;
         //修改状态反馈

--- a/sources/Alife.DeskPet/Alife.DeskPet.Protocol/PetModelMetadata.cs
+++ b/sources/Alife.DeskPet/Alife.DeskPet.Protocol/PetModelMetadata.cs
@@ -24,6 +24,17 @@ public class PetModelMetadata
     public Dictionary<string, List<InteractionItem>> Interactions { get; } = new();
     public string ModelPath { get; private set; } = string.Empty;
 
+    public static string ResolveModelJsonPath(string modelRootPath, string modelName)
+    {
+        string model3JsonPath = Path.Combine(modelRootPath, modelName, $"{modelName}.model3.json");
+        if (File.Exists(model3JsonPath)) return model3JsonPath;
+
+        string modelJsonPath = Path.Combine(modelRootPath, modelName, $"{modelName}.model.json");
+        if (File.Exists(modelJsonPath)) return modelJsonPath;
+
+        return model3JsonPath;
+    }
+
     public static PetModelMetadata Load(string jsonPath)
     {
         PetModelMetadata metadata = new();
@@ -70,6 +81,43 @@ public class PetModelMetadata
                                 string? name = nameProp.GetString();
                                 if (string.IsNullOrEmpty(name) == false) metadata.Motions[name] = (groupName, index);
                             }
+                            index++;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (root.TryGetProperty("expressions", out JsonElement exps))
+                {
+                    foreach (JsonElement exp in exps.EnumerateArray())
+                    {
+                        if (exp.TryGetProperty("name", out JsonElement nameProp))
+                        {
+                            string? name = nameProp.GetString();
+                            if (string.IsNullOrEmpty(name) == false) metadata.Expressions.Add(name);
+                        }
+                    }
+                }
+
+                if (root.TryGetProperty("motions", out JsonElement motionsJson))
+                {
+                    foreach (JsonProperty groupProp in motionsJson.EnumerateObject())
+                    {
+                        string groupName = groupProp.Name;
+                        int index = 0;
+                        foreach (JsonElement motionItem in groupProp.Value.EnumerateArray())
+                        {
+                            string? name = null;
+                            if (motionItem.TryGetProperty("name", out JsonElement nameProp))
+                            {
+                                name = nameProp.GetString();
+                            }
+                            if (string.IsNullOrEmpty(name) && motionItem.TryGetProperty("file", out JsonElement fileProp))
+                            {
+                                name = Path.GetFileNameWithoutExtension(fileProp.GetString());
+                            }
+                            if (string.IsNullOrEmpty(name) == false) metadata.Motions[name] = (groupName, index);
                             index++;
                         }
                     }

--- a/sources/Alife.Function/Alife.Function.DeskPet/DeskPetServiceUI.razor
+++ b/sources/Alife.Function/Alife.Function.DeskPet/DeskPetServiceUI.razor
@@ -13,7 +13,7 @@
             <FormItem Label="模型名">
                 <Input @bind-Value="@Configuration.ModelName" Placeholder="Mao"/>
                 <Text Type="TextElementType.Secondary" Style="font-size: 11px;">
-                    输入模型文件夹名称，将按 <code>{名称}/{名称}.model3.json</code> 规则
+                    输入模型文件夹名称，将按 <code>{名称}/{名称}.model3.json</code> 或 <code>{名称}/{名称}.model.json</code> 规则
                     从 <code>wwwroot/model/</code> 目录加载。留空或 "Mao" 为默认角色。
                 </Text>
             </FormItem>
@@ -27,10 +27,10 @@
             <div style="padding: 8px 0; font-size: 13px; line-height: 1.8;">
                 <Text Type="TextElementType.Secondary">
                     1. 将 Live2D Cubism 模型文件夹放入程序目录下的 <code>wwwroot/model/</code> 中。<br/>
-                    2. 输入文件夹名即可加载，系统自动按 <code>{{名称}}/{{名称}}.model3.json</code> 定位。<br/>
+                    2. 输入文件夹名即可加载，系统自动按 <code>{{名称}}/{{名称}}.model3.json</code> 或 <code>{{名称}}/{{名称}}.model.json</code> 定位。<br/>
                     3. 本系统额外支持 <code>Interaction</code> 扩展字段，定义点击/晃动/启动等交互反馈。
                     每个交互可以配置随机触发的<strong>气泡文本 + 表情 + 动作</strong>组合。
-                    格式参考 <code>Mao.model3.json</code> 中的同名顶层字段。<br/>
+                    格式参考 <code>Mao.model3.json</code> 中的同名顶层字段；Cubism 2 模型可在 <code>.model.json</code> 中添加同名顶层字段。<br/>
                     4. 如不提供 <code>Interaction</code> 字段，模型可正常显示但无互动反馈。<br/>
                     5. 目前支持 8 种交互类型：<code>head</code>、<code>body</code>、<code>rotate</code>、
                     <code>window_shake</code>、<code>window_move</code>、<code>mouse_shake</code>、

--- a/sources/Alife.Function/Alife.Function.DeskPet/PetServer.cs
+++ b/sources/Alife.Function/Alife.Function.DeskPet/PetServer.cs
@@ -23,7 +23,7 @@ public class PetServer : IAsyncDisposable
     public PetServer(string clientPath, string modelName)
     {
         //加载模型信息
-        string modelJsonPath = Path.Combine(clientPath, $"wwwroot/model/{modelName}/{modelName}.model3.json");
+        string modelJsonPath = PetModelMetadata.ResolveModelJsonPath(Path.Combine(clientPath, "wwwroot/model"), modelName);
         metadata = PetModelMetadata.Load(modelJsonPath);
 
         //创建进程


### PR DESCRIPTION
增加同时支持cubism2模型。
主要改动：
PetModelMetadata.cs (line 27)：新增 ResolveModelJsonPath(...)，优先找 .model3.json，找不到再找 .model.json。
PetModelMetadata.cs (line 91)：补了 Cubism 2 的 expressions / motions 小写字段解析。
PetServer.cs (line 26)：主程序按新规则定位模型 JSON。
App.xaml.cs (line 25)：桌宠客户端默认模型路径也改成同一套规则。
DeskPetServiceUI.razor (line 16)：配置页提示已更新，说明支持 .model3.json 和 .model.json。