### PR TITLE
fix: prevent Collection was modified crash with defensive .ToList() snapshots

### DIFF
--- a/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatHistoryUI.razor
+++ b/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatHistoryUI.razor
@@ -122,7 +122,8 @@
     IEnumerable<ChatMessageContent> GetFilteredHistory()
     {
         if (Activity == null) return [];
-        var history = Activity.ChatBot.ChatHistory.AsEnumerable();
+        // 防御快照：ChatHistory 可能在 Blazor 渲染期间被后台线程修改
+        var history = Activity.ChatBot.ChatHistory.ToList();
 
         return historyRoleFilter switch {
             "Chat" => history.Where(c => !IsKeyMemory(c) && (c.Role.ToString().Equals("user", StringComparison.OrdinalIgnoreCase) || c.Role.ToString().Equals("assistant", StringComparison.OrdinalIgnoreCase))),

--- a/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatWindowUI.razor
+++ b/sources/Alife/Alife.Client/Components/Pages/CharacterWorkspacePage/ChatWindowUI.razor
@@ -36,10 +36,8 @@
             }
             else
             {
-                @lock (messages)
+                @foreach (ChatMessage message in messages.ToList())
                 {
-                    @foreach (ChatMessage message in messages)
-                    {
                         <div
                             style="display: flex; margin-bottom: 16px; width: 100%; @(message.IsUser ? "flex-direction: row-reverse" : "flex-direction: row")">
                             <div class="chat-bubble @(message.IsUser ? "chat-bubble-user" : "chat-bubble-ai")">
@@ -75,7 +73,6 @@
                     }
                 }
             }
-        }
         else
         {
             <Empty Description="@("消息存储不存在！")"/>


### PR DESCRIPTION
## Problem

Alife throws `InvalidOperationException: Collection was modified; enumeration operation may not execute.` during Blazor rendering, followed by `UnobservedTaskException` from the finalizer thread. The UI freezes but conversation continues in the background.

This happens because mutable collections (`ChatHistory`, `messages`) are enumerated during `BuildRenderTree` while background threads (e.g., auditory model `Recognized` events from audio thread) concurrently modify them.

## Root Cause

Two components share the same class of race condition:

1. **ChatHistoryUI.razor**: `GetFilteredHistory()` returns `ChatHistory.AsEnumerable()` (lazy), and `.ToList()` is deferred until after `.Select()`. The underlying `ChatHistory` (a `List<ChatMessageContent>`) can be modified during enumeration.

2. **ChatWindowUI.razor**: `@foreach` iterates `messages` (a `List<ChatMessage>`) while `ChatMessageService` concurrently adds/removes messages. The existing `@lock(messages)` is ineffective because mutators don't take the same lock.

## Fix

Two-line defense following standard Blazor pattern:

| File | Change |
|------|--------|
| `ChatHistoryUI.razor:125` | `ChatHistory.AsEnumerable()` → `ChatHistory.ToList()` — materializes snapshot before filtering |
| `ChatWindowUI.razor:38` | `@foreach (ChatMessage message in messages)` → `messages.ToList()` — iterates snapshot, removes ineffective `@lock` |

This prevents the crash regardless of when/how the original collection is modified.

## Verification

- No crash when auditory module fires `Recognized` events on audio thread during Blazor rendering
- No change to UI behavior — snapshots are discarded after each render cycle
- Memory overhead negligible — chat history is typically <1000 entries
