### PR TITLE
增加deepwiki徽章并调整为与原文案其他徽章一致大小

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ![Alife Logo](https://img.shields.io/badge/Alife-AI_Assistant-blue?style=for-the-badge)
 ![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?style=for-the-badge&logo=dotnet)
 ![Python 3.12](https://img.shields.io/badge/Python-3.12-3776AB?style=for-the-badge&logo=python)
-<a href="https://github.com/BDFFZI/Alife"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" width="150"></a>
+<a href="https://deepwiki.com/BDFFZI/Alife"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" width="150"></a>
 ![License](https://img.shields.io/badge/license-AGPL--3.0-green?style=for-the-badge)
 
 欢迎来到 Alife！

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ![Alife Logo](https://img.shields.io/badge/Alife-AI_Assistant-blue?style=for-the-badge)
 ![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?style=for-the-badge&logo=dotnet)
 ![Python 3.12](https://img.shields.io/badge/Python-3.12-3776AB?style=for-the-badge&logo=python)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://github.com/BDFFZI/Alife)
+![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://github.com/BDFFZI/Alife)
 ![License](https://img.shields.io/badge/license-AGPL--3.0-green?style=for-the-badge)
 
 欢迎来到 Alife！

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ![Alife Logo](https://img.shields.io/badge/Alife-AI_Assistant-blue?style=for-the-badge)
 ![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?style=for-the-badge&logo=dotnet)
 ![Python 3.12](https://img.shields.io/badge/Python-3.12-3776AB?style=for-the-badge&logo=python)
-![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://github.com/BDFFZI/Alife)
+<a href="https://github.com/BDFFZI/Alife"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" width="150"></a>
 ![License](https://img.shields.io/badge/license-AGPL--3.0-green?style=for-the-badge)
 
 欢迎来到 Alife！

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 ![Alife Logo](https://img.shields.io/badge/Alife-AI_Assistant-blue?style=for-the-badge)
 ![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?style=for-the-badge&logo=dotnet)
 ![Python 3.12](https://img.shields.io/badge/Python-3.12-3776AB?style=for-the-badge&logo=python)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://github.com/BDFFZI/Alife)
 ![License](https://img.shields.io/badge/license-AGPL--3.0-green?style=for-the-badge)
 
 欢迎来到 Alife！


### PR DESCRIPTION
通过添加deepwiki徽章，可让本项目约每周自动更新最新的百科，便于用户和agent自查询